### PR TITLE
Refactored prettier to prettier/standalone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "readability",
+  "name": "markdown-wiki",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "readability",
+      "name": "markdown-wiki",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -17,7 +17,7 @@
         "set-operations": "1.2.2",
         "text-readability": "1.0.5",
         "url-regex": "5.0.0",
-        "valid-url": "^1.0.9",
+        "valid-url": "1.0.9",
         "wordcount": "1.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "vscode": "^1.68.0",
     "node": ">=16"
   },
   "main": "./dist/extension.js",
@@ -88,7 +87,7 @@
     "@types/mocha": "9.1.1",
     "@types/node": "16.11.41",
     "@types/prettier": "2.6.3",
-    "@types/valid-url": "^1.0.3",
+    "@types/valid-url": "1.0.3",
     "@types/vscode": "1.68.0",
     "@typescript-eslint/eslint-plugin": "5.28.0",
     "@typescript-eslint/parser": "5.28.0",
@@ -110,7 +109,7 @@
     "set-operations": "1.2.2",
     "text-readability": "1.0.5",
     "url-regex": "5.0.0",
-    "valid-url": "^1.0.9",
+    "valid-url": "1.0.9",
     "wordcount": "1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
+    "vscode": "^1.68.0",
     "node": ">=16"
   },
   "main": "./dist/extension.js",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+
 import {
   insertFootnote,
   reorderFootnotesInFile,

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,6 +1,7 @@
+import * as vscode from 'vscode'
+
 // Reference: https://github.com/microsoft/vscode-extension-samples/blob/main/code-actions-sample/src/diagnostics.ts
 import { split } from 'sentence-splitter'
-import * as vscode from 'vscode'
 
 // Library to analyze the readability of text
 const rs = require('text-readability')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,13 @@
 // Reference: https://github.com/microsoft/vscode-extension-samples/blob/main/code-actions-sample/src/extension.ts
 import * as vscode from 'vscode'
-import { subscribeToDocumentChanges } from './diagnostics'
+
 import {
   insertFootnoteCommand,
   reorderFootnotesInFileCommand,
   reorderFootnotesInWorkspaceCommand,
 } from './commands'
+
+import { subscribeToDocumentChanges } from './diagnostics'
 
 export function activate(context: vscode.ExtensionContext) {
   const readabilityDiagnostics =

--- a/src/helpers/footnotes.ts
+++ b/src/helpers/footnotes.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs'
-import { customAlphabet } from 'nanoid'
-import prettier from 'prettier'
-import { difference } from 'set-operations'
 import * as vscode from 'vscode'
+
+import { customAlphabet } from 'nanoid'
+import { difference } from 'set-operations'
 import glob from 'glob'
 import { isWebUri } from 'valid-url'
+import parserMarkdown from 'prettier/parser-markdown'
+import prettier from 'prettier/standalone'
 
 const footnoteRegex = /(\[\^\w+\])(?!(: ))/g
 const endnoteRegex = /(\[\^\w+\]): (.*)/g
@@ -90,7 +92,13 @@ export const reorderFootnotes = (
   })
 
   // Finally, we format the contents and overwrite the old file
-  fs.writeFileSync(file, prettier.format(newContents, { parser: 'markdown' }))
+  fs.writeFileSync(
+    file,
+    prettier.format(newContents, {
+      plugins: [parserMarkdown],
+      parser: 'markdown',
+    })
+  )
   vscode.window.showInformationMessage('Footnotes reordered and formatted!')
 }
 


### PR DESCRIPTION
## What did you do?

- Refactored prettier to `prettier/standalone` to eliminate Webpack errors and lengthy build times.